### PR TITLE
Looking for lanes or addressess

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,35 @@ Exemple de configuration :
             "key": "xxxxxxxxxxxxxxxxxxxxxx",
             "zoomLevel": 18,
             "minChars": 7,
-            "graphicStyle": {
+            "laneLabelMaxScaleDenominator": 300000,
+            "addressLabelMaxScaleDenominator": 5000,
+            "laneStyle": {
+                "strokeColor": "blue",
+                "strokeWidth": 2,
+                "fillOpacity": 0,
+                "label": "${name3}",
+                "fontColor": "blue",
+                "fontSize": 12,
+                "fontFamily": "serif",
+                "labelYOffset": "15",
+                "labelOutlineColor": "white",
+                "labelOutlineWidth": 3
+            },
+            "addressStyle": {
                 "graphicName": "star",
                 "pointRadius": 4,
                 "strokeColor": "fuchsia",
                 "strokeWidth": 2,
-                "fillOpacity": 0
-            }
+                "fillOpacity": 0,
+                "label": "${addr2}",
+                "fontColor": "fuchsia",
+                "fontSize": 10,
+                "fontFamily": "serif",
+                "labelAlign": "cc",
+                "labelYOffset": "15",
+                "labelOutlineColor": "white",
+                "labelOutlineWidth": 3
+            },
         },
         "title": {
             "en": "RVA",

--- a/js/OpenLayers.Format.RVA.js
+++ b/js/OpenLayers.Format.RVA.js
@@ -93,4 +93,100 @@ OpenLayers.Format.RVA = OpenLayers.Class(OpenLayers.Format.JSON, {
 
     CLASS_NAME: "OpenLayers.Format.RVA" 
 
-});     
+});
+
+/**
+ * Class: OpenLayers.Format.RVALane
+ *
+ * Inherits from:
+ *  - <OpenLayers.Format.JSON>
+ */
+OpenLayers.Format.RVALane = OpenLayers.Class(OpenLayers.Format.JSON, {
+
+    /**
+     * APIMethod: read
+     * Deserialize an RVA JSON string.
+     *
+     * Parameters:
+     * json - {String} An RVA JSON string
+     *
+     * Returns:
+     * {Object} an array of <OpenLayers.Feature.Vector>.
+     */
+    read: function(json, filter) {
+        var results = null;
+        var obj = null;
+        if (typeof json == "string") {
+            obj = OpenLayers.Format.JSON.prototype.read.apply(this,
+                [json, filter]);
+        } else {
+            obj = json;
+        }
+        if(!obj) {
+            OpenLayers.Console.error("Bad JSON: " + json);
+        } else if(typeof(obj.rva) != "object") {
+            OpenLayers.Console.error("Bad RVA response - " + json);
+        } else {
+            results = [];
+            var lanes = obj.rva.answer.lanes;
+            for(var i=0, len=lanes.length; i<len; ++i) {
+                try {
+                    results.push(this.parseFeature(lanes[i]));
+                } catch(err) {
+                    results = null;
+                    OpenLayers.Console.error(err);
+                }
+            }
+        }
+        return results;
+    },
+
+    /**
+     * Method: parseFeature
+     * Convert an address object into an
+     *     <OpenLayers.Feature.Vector>.
+     *
+     * Parameters:
+     * obj - {Object}
+     *
+     * Returns:
+     * {<OpenLayers.Feature.Vector>} A feature.
+     */
+    parseFeature: function(obj) {
+        var feature, geometry;
+        try {
+            geometry = this.parseGeometry(obj.lowerCorner, obj.upperCorner);
+        } catch(err) {
+            throw err;
+        }
+        feature = new OpenLayers.Feature.Vector(geometry, obj);
+        if (obj.idlanes) {
+            feature.fid = obj.idlanes;
+        }
+        return feature;
+    },
+
+    /**
+     * Method: parseGeometry
+     *
+     * Parameters:
+     * lowerCorner - {String} "left bottom"
+     * upperCorner - {String} "right up"
+     *
+     * Returns:
+     * {<OpenLayers.Geometry>} A geometry.
+     */
+    parseGeometry: function(lowerCorner, upperCorner) {
+        var bounds = new OpenLayers.Bounds(lowerCorner.split(" ")[1], lowerCorner.split(" ")[0],
+            upperCorner.split(" ")[1], upperCorner.split(" ")[0]);
+        var geometry = bounds.toGeometry();
+        if (this.internalProjection && this.externalProjection) {
+            geometry.transform(this.externalProjection,
+                this.internalProjection);
+        }
+        return geometry;
+    },
+
+    CLASS_NAME: "OpenLayers.Format.RVALane"
+
+});

--- a/js/OpenLayers.Format.RVA.js
+++ b/js/OpenLayers.Format.RVA.js
@@ -177,8 +177,8 @@ OpenLayers.Format.RVALane = OpenLayers.Class(OpenLayers.Format.JSON, {
      * {<OpenLayers.Geometry>} A geometry.
      */
     parseGeometry: function(lowerCorner, upperCorner) {
-        var bounds = new OpenLayers.Bounds(lowerCorner.split(" ")[1], lowerCorner.split(" ")[0],
-            upperCorner.split(" ")[1], upperCorner.split(" ")[0]);
+        var bounds = new OpenLayers.Bounds(lowerCorner.split(" ")[0], lowerCorner.split(" ")[1],
+            upperCorner.split(" ")[0], upperCorner.split(" ")[1]);
         var geometry = bounds.toGeometry();
         if (this.internalProjection && this.externalProjection) {
             geometry.transform(this.externalProjection,

--- a/js/main.js
+++ b/js/main.js
@@ -50,7 +50,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                     if (this.state !== "searchlane") {
                         console.log("searchlane");
                         this.combo = this.combo.cloneConfig({
-                            store: this._createLanesStore(),
+                            store: this._createStore("lanes"),
                             tpl: new Ext.XTemplate(
                                 '<tpl for="."><div class="x-combo-list-item" ext:qtip="{values.feature.attributes.name}">',
                                 '{values.feature.attributes.name}',
@@ -80,7 +80,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                     if (this.state !== "searchaddress") {
                         console.log("searchaddress");
                         this.combo = this.combo.cloneConfig({
-                            store: this._createStore(),
+                            store: this._createStore("fullAddresses"),
                             tpl: new Ext.XTemplate(
                                 '<tpl for="."><div class="x-combo-list-item" ext:qtip="{values.feature.attributes.addr3}">',
                                 '{values.feature.attributes.addr3}',
@@ -124,7 +124,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                 '{values.feature.attributes.name}',
                 '</div></tpl>'
             ),
-            store: this._createLanesStore(),
+            store: this._createStore("lanes"),
             emptyText: tr("addon_rva_emptyText"),
             triggerAction: 'all',
             width: 250,
@@ -179,7 +179,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                 {
                     id: "rva-lane-grid",
                     xtype: "grid",
-                    store: this._createAddressesStore(""),
+                    store: this._createStore("addresses"),
                     autoExpandColumn: "addr3",
                     columns: [
                         {id: 'insee', header: "Insee", dataIndex: "insee", width: 60},
@@ -241,9 +241,10 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
 
     /**
      * Method: _createStore
-     *
      */
-    _createStore: function() {
+    _createStore: function(storeType) {
+        var proxyCommand, proxyParams, rvaFormat, storeFields, storeSortInfo;
+
         var api_srs = null,
             formatOptions = {},
             map_srs = this.map.getProjection().split(':')[1];
@@ -260,197 +261,25 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                 externalProjection: new OpenLayers.Projection("EPSG:4326")
             };
         }
-        return new GeoExt.data.FeatureStore({
-            fields: [
-                'insee',
-                {name: 'idlane', type: "int"},
-                {name: 'number', type: "int"},
-                'extension',
-                'building',
-                'addr3'
-            ],
-            layer: this.layer,
-            proxy: new GeoExt.data.ProtocolProxy({
-                protocol: new OpenLayers.Protocol.HTTP({
-                    url: this.options.service,
-                    params: {
-                        key: this.options.key,
-                        version: '1.0',
-                        format: 'json',
-                        epsg: api_srs,
-                        cmd: 'getfulladdresses'
-                    },
-                    format: new OpenLayers.Format.RVA(formatOptions)
-                })
-            }),
-            hasMultiSort: true,
-            multiSortInfo: {
-                sorters: [{
-                    field: 'insee',
-                    direction: "ASC"
-                }, {
-                    field: 'idlane',
-                    direction: "ASC"
-                }, {
-                    field: 'number',
-                    direction: "ASC"
-                }, {
-                    field: 'extension',
-                    direction: "ASC"
-                }, {
-                    field: 'building',
-                    direction: "ASC"
-                }],
-                direction: 'ASC'
-            },
-            listeners: {
-                'datachanged': function(store) {
-                    this.popup && this.popup.close();
-                    if (store.getCount() == 0) {
-                        return;
-                    }
-                    var bounds = new OpenLayers.Bounds(),
-                        records = store.getRange();
-                    Ext.each(records, function(r) {
-                        var f = r.getFeature();
-                        // copy feature attributes to record:
-                        Ext.applyIf(r.data, f.attributes);
-                        if (f.geometry) {
-                            bounds.extend(f.geometry.getBounds());
-                        }
-                    });
-                    this.map.zoomToExtent(bounds);
-                },
-                scope: this
-            }
-        });
-    },
 
-    /**
-     * Method: _createAddressesStore
-     *
-     */
-    _createAddressesStore: function(idlane) {
-        var store = null,
-            api_srs = null,
-            formatOptions = {},
-            map_srs = this.map.getProjection().split(':')[1];
-
-        if (this.options.supported_srs.indexOf(map_srs) > -1) {
-            // the API natively supports our map SRS
-            // let's use this SRS.
-            api_srs = map_srs;
-        } else {
-            // we have to reproject client side
-            api_srs = 4326;
-            formatOptions = {
-                internalProjection: new OpenLayers.Projection("EPSG:" + map_srs),
-                externalProjection: new OpenLayers.Projection("EPSG:4326")
-            };
+        proxyParams = {
+            key: this.options.key,
+            version: '1.0',
+            format: 'json',
+            epsg: api_srs,
         }
-        store = new GeoExt.data.FeatureStore({
-            fields: [
-                'insee',
-                {name: 'idlane', type: "int"},
-                {name: "idaddress", type: "int"},
-                {name: 'number', type: "int"},
-                'extension',
-                'building',
-                'addr3'
-            ],
-            layer: this.layer,
-            proxy: new GeoExt.data.ProtocolProxy({
-                protocol: new OpenLayers.Protocol.HTTP({
-                    url: this.options.service,
-                    params: {
-                        key: this.options.key,
-                        version: '1.0',
-                        format: 'json',
-                        epsg: api_srs,
-                        cmd: 'getaddresses'
-                    },
-                    format: new OpenLayers.Format.RVA(formatOptions)
-                })
-            }),
-            hasMultiSort: true,
-            multiSortInfo: {
-                sorters: [{
-                    field: 'insee',
-                    direction: "ASC"
-                }, {
-                    field: 'idlane',
-                    direction: "ASC"
-                }, {
-                    field: 'number',
-                    direction: "ASC"
-                }, {
-                    field: 'extension',
-                    direction: "ASC"
-                }, {
-                    field: 'building',
-                    direction: "ASC"
-                }],
-                direction: 'ASC'
-            },
-            listeners: {
-                "load": {
-                    fn: function(store) {
-                        store.filter({
-                            fn: function(record) {
-                                return record.get("number") > 0;
-                            }
-                        })
-                    }
-                }
-            }
-        });
-        return store;
-    },
 
-    /**
-     * Method: _createLanesStore
-     *
-     */
-    _createLanesStore: function() {
-        var api_srs = null,
-            formatOptions = {},
-            map_srs = this.map.getProjection().split(':')[1];
-
-        if (this.options.supported_srs.indexOf(map_srs) > -1) {
-            // the API natively supports our map SRS
-            // let's use this SRS.
-            api_srs = map_srs;
-        } else {
-            // we have to reproject client side
-            api_srs = 4326;
-            formatOptions = {
-                internalProjection: new OpenLayers.Projection("EPSG:" + map_srs),
-                externalProjection: new OpenLayers.Projection("EPSG:4326")
-            };
-        }
-        return new GeoExt.data.FeatureStore({
-            fields: [
+        if (storeType === "lanes") {
+            proxyParams.cmd = "getlanes";
+            proxyParams.insee = "all"
+            ;
+            rvaFormat = OpenLayers.Format.RVALane;
+            storeFields = [
                 'insee',
                 'name',
                 'name3'
-            ],
-            layer: this.layerLane,
-            proxy: new GeoExt.data.ProtocolProxy({
-                protocol: new OpenLayers.Protocol.HTTP({
-                    url: this.options.service,
-                    params: {
-                        key: this.options.key,
-                        version: '1.0',
-                        format: 'json',
-                        epsg: api_srs,
-                        insee: 'all',
-                        cmd: 'getlanes'
-                    },
-                    format: new OpenLayers.Format.RVALane(formatOptions)
-                })
-            }),
-            hasMultiSort: true,
-            multiSortInfo: {
+            ];
+            storeSortInfo = {
                 sorters: [{
                     field: 'insee',
                     direction: "ASC"
@@ -459,7 +288,57 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                     direction: "ASC"
                 }],
                 direction: 'ASC'
-            },
+            }
+        } else if ((storeType === "fullAddresses") || (storeType == "addresses")) {
+            rvaFormat = OpenLayers.Format.RVA;
+            storeFields = [
+                'insee',
+                {name: 'idlane', type: "int"},
+                {name: 'number', type: "int"},
+                'extension',
+                'building',
+                'addr3'
+            ];
+            storeSortInfo = {
+                sorters: [{
+                    field: 'insee',
+                    direction: "ASC"
+                }, {
+                    field: 'idlane',
+                    direction: "ASC"
+                }, {
+                    field: 'number',
+                    direction: "ASC"
+                }, {
+                    field: 'extension',
+                    direction: "ASC"
+                }, {
+                    field: 'building',
+                    direction: "ASC"
+                }],
+                direction: 'ASC'
+            };
+
+            if (storeType === "fullAddresses") {
+                proxyParams.cmd = "getfulladdresses";
+
+            } else if (storeType == "addresses") {
+                proxyParams.cmd = "getaddresses";
+            }
+        }
+
+        return new GeoExt.data.FeatureStore({
+            fields: storeFields,
+            layer: this.layer,
+            proxy: new GeoExt.data.ProtocolProxy({
+                protocol: new OpenLayers.Protocol.HTTP({
+                    url: this.options.service,
+                    params: proxyParams,
+                    format: new rvaFormat(formatOptions)
+                })
+            }),
+            hasMultiSort: true,
+            multiSortInfo: storeSortInfo,
             listeners: {
                 'datachanged': function(store) {
                     this.popup && this.popup.close();
@@ -482,7 +361,6 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             }
         });
     },
-
 
     /**
      * Method: _onComboSelect

--- a/js/main.js
+++ b/js/main.js
@@ -65,6 +65,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                         });
                         this.target.setActiveTab(2);
                         this.combo.setValue(query.query);
+                        this.combo.focus();
                     }
                     this.state = "searchlane";
 
@@ -74,6 +75,29 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             },
             "searchaddress": {
                 fn: function(query) {
+                    if (this.state !== "searchaddress") {
+                        this.combo = this.combo.cloneConfig({
+                            store: this._createStore(),
+                            tpl: new Ext.XTemplate(
+                                '<tpl for="."><div class="x-combo-list-item" ext:qtip="{values.feature.attributes.addr3}">',
+                                '{values.feature.attributes.addr3}',
+                                '</div></tpl>'
+                            )
+                        });
+                        this.components.destroy();
+                        this.components = this.target.insert(this.position, {
+                            xtype: 'form',
+                            bodyStyle: 'padding: 1.5em;',
+                            title: tr("addon_rva_tabTitle"),
+                            labelWidth: 1,
+                            items: this.combo
+                        });
+                        this.target.setActiveTab(2);
+                        this.combo.setValue(query.query);
+                        this.combo.focus();
+
+                    }
+                    this.state = "searchaddress";
 
                 },
                 scope: this

--- a/js/main.js
+++ b/js/main.js
@@ -26,7 +26,11 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
         this.map.addLayer(this.layer);
         this.map.addLayer(this.layerLane);
 
-        this.state = "searchaddress";
+        /**
+         * By default, the combobox is looking for lane
+         * @type {string}
+         */
+        this.state = "searchlane";
 
         this.events = new Ext.util.Observable();
 
@@ -131,11 +135,11 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             queryDelay: 100,
             displayField: "addr3",
             tpl: new Ext.XTemplate(
-                '<tpl for="."><div class="x-combo-list-item" ext:qtip="{values.feature.attributes.addr3}">',
-                '{values.feature.attributes.addr3}',
+                '<tpl for="."><div class="x-combo-list-item" ext:qtip="{values.feature.attributes.name}">',
+                '{values.feature.attributes.name}',
                 '</div></tpl>'
             ),
-            store: this._createStore(),
+            store: this._createLanesStore(),
             emptyText: tr("addon_rva_emptyText"),
             triggerAction: 'all',
             width: 250,
@@ -221,10 +225,10 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                     handler: function() {
                         var grid = Ext.getCmp("rva-lane-grid"),
                             row, columns = [], data = [];
-                        for (var c=0; c < grid.getColumnModel().getColumnCount(); c++){
-                            columns.splice(-1,0,grid.getColumnModel().getDataIndex(c));
+                        for (var c = 0; c < grid.getColumnModel().getColumnCount(); c++) {
+                            columns.splice(-1, 0, grid.getColumnModel().getDataIndex(c));
                         }
-                        grid.getStore().each(function (record) {
+                        grid.getStore().each(function(record) {
                             row = [];
                             for (c in columns) {
                                 row.push(record.get(columns[c]));

--- a/js/main.js
+++ b/js/main.js
@@ -215,7 +215,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                         }
                         grid.getStore().each(function(record) {
                             row = [];
-                            for (c in columns) {
+                            for (var c=0; c < columns.length; c++) {
                                 row.push(record.get(columns[c]));
                             }
                             data.push(row);

--- a/js/main.js
+++ b/js/main.js
@@ -157,6 +157,52 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
         // switch to this new tab:
         this.target.layout.setActiveItem(this.components);
         this.target.doLayout();
+
+        me = this;
+        this.laneWindow = new Ext.Window({
+            //TODO tr
+            title: "Adresses sur la voie",
+            layout: "table",
+            layoutConfig: {
+                columns: 1
+            },
+            width: 540,
+            autoHeight: true,
+            closable: true,
+            closeAction: "hide",
+            items: [
+                {
+                    id: "rva-lane-grid",
+                    xtype: "grid",
+                    store: this._createAddressesStore(""),
+                    autoExpandColumn: "addr3",
+                    columns: [
+                        {id: 'insee', header: "Insee", dataIndex: "insee", width: 60},
+                        {id: "idaddres", header: "Idaddress", dataIndex: "idaddress", width: 60},
+                        {id: "number", header: "Num.", dataIndex: "number", width: 40},
+                        {id: 'extension', header: "Ext", dataIndex: "extension", width: 40},
+                        {id: 'building', header: "Bât", dataIndex: "building", width: 40},
+                        {id: 'addr3', header: "Adresse", dataIndex: "addr3"}
+                    ],
+                    sm: new GeoExt.grid.FeatureSelectionModel({
+                        autoPanMapOnSelection: true
+                    }),
+                    width: 520,
+                    height: 520,
+                    frame: true
+                }
+            ],
+            buttons: [
+                {
+                    text: "Close",
+                    handler: function() {
+                        this.laneWindow.hide();
+                    },
+                    scope: this
+                }
+            ]
+
+        });
     },
 
     /**
@@ -269,7 +315,6 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             };
         }
         store = new GeoExt.data.FeatureStore({
-            autoLoad: true,
             fields: [
                 'insee',
                 {name: 'idlane', type: "int"},
@@ -288,8 +333,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                         version: '1.0',
                         format: 'json',
                         epsg: api_srs,
-                        cmd: 'getaddresses',
-                        idlane: idlane
+                        cmd: 'getaddresses'
                     },
                     format: new OpenLayers.Format.RVA(formatOptions)
                 })
@@ -444,55 +488,18 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             this.layer.addFeatures([f]);
             this.map.zoomToExtent(this.layer.getDataExtent());
 
-            this.laneWindow = new Ext.Window({
-                //TODO tr
-                title: "Adresses sur la voie",
-                width: 540,
-                autoHeight: true,
-                maxHeight: 540,
-                closable: true,
-                closeAction: "hide",
-                items: [
-                    {
-                        xtype: "grid",
-                        store: this._createAddressesStore(f.attributes.idlane),
-                        autoExpandColumn: "addr3",
-                        colModel: new Ext.grid.ColumnModel({
-                            defaults: {
-                                sortable: true
-                            },
-                            //TODO tr
-                            columns: [
-                                {id: 'insee', header: "Insee", dataIndex: "insee", width: 60},
-                                {id: "idaddres", header: "Idaddress", dataIndex: "idaddress", width: 60},
-                                {id: "number", header: "Num.", dataIndex: "number", width: 40},
-                                {id: 'extension', header: "Ext", dataIndex: "extension", width: 40},
-                                {id: 'building', header: "Bât", dataIndex: "building", width: 40},
-                                {id: 'addr3', header: "Adresse", dataIndex: "addr3"}
-                            ]
-                        }),
-                        sm: new Ext.grid.RowSelectionModel({
-                            singleSelect: true,
-                            listeners: {
-                                "rowselect": {
-                                    fn: function(sm, idx, r) {
-                                        var lonlat = new OpenLayers.LonLat(r.data.feature.geometry.x,
-                                            r.data.feature.geometry.y);
-                                        this.map.panTo(lonlat);
-                                    },
-                                    scope: this
-                                }
-                            }
-                        }),
-                        width: 520,
-                        autoHeight: true,
-                        frame: true
-                    }
-                ]
 
-            });
-
-            this.laneWindow.show();
+            var laneGrid = Ext.getCmp("rva-lane-grid");
+            laneGrid.getStore().load({
+                    params: {
+                        idlane: f.attributes.idlane
+                    },
+                    callback: function() {
+                        this.laneWindow.show();
+                    },
+                    scope: this
+                }
+            );
 
         }
 

--- a/js/main.js
+++ b/js/main.js
@@ -44,21 +44,6 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
          */
         this.events.addEvents("searchaddress");
 
-        /**
-         * We are not looking for anything
-         */
-        this.events.addEvents("searchnoting");
-
-        /**
-         * We selected a lane
-         */
-        this.events.addEvents("laneselected");
-
-        /**
-         * We selected an address
-         */
-        this.events.addEvents("adressselected");
-
         this.events.on({
             "searchlane": {
                 fn: function(query) {

--- a/js/main.js
+++ b/js/main.js
@@ -48,7 +48,6 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             "searchlane": {
                 fn: function(query) {
                     if (this.state !== "searchlane") {
-                        console.log("searchlane");
                         this.combo = this.combo.cloneConfig({
                             store: this._createStore("lanes"),
                             tpl: new Ext.XTemplate(
@@ -78,7 +77,6 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             "searchaddress": {
                 fn: function(query) {
                     if (this.state !== "searchaddress") {
-                        console.log("searchaddress");
                         this.combo = this.combo.cloneConfig({
                             store: this._createStore("fullAddresses"),
                             tpl: new Ext.XTemplate(

--- a/js/main.js
+++ b/js/main.js
@@ -328,40 +328,52 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
      * Callback on combo selected
      */
     _onComboSelect: function(combo, record) {
-        var f = record.get('feature').clone();
-        this.layer.destroyFeatures();
-        this.popup && this.popup.destroy();
-        this.map.setCenter(f.geometry.getBounds().getCenterLonLat());
-        this.layer.addFeatures([f]);
-        this.popup = new GeoExt.Popup({
-            location: f,
-            width: 300,
-            tpl: ["<p>{address}</p><p>idaddress : {idaddress}</p>"],
-            data: {
-                address: f.attributes.addr3,
-                idaddress: f.attributes.idaddress
-            },
-            anchorPosition: "top-left",
-            bodyStyle: "padding: 5px;",
-            collapsible: false,
-            closable: true,
-            closeAction: "hide",
-            unpinnable: true,
-            listeners: {
-                "hide": function() {
-                    this.layer.destroyFeatures();
+        if (this.state === "searchaddress") {
+            var f = record.get('feature').clone();
+            this.layer.destroyFeatures();
+            this.popup && this.popup.destroy();
+            this.map.setCenter(f.geometry.getBounds().getCenterLonLat());
+            this.layer.addFeatures([f]);
+            this.popup = new GeoExt.Popup({
+                location: f,
+                width: 300,
+                tpl: ["<p>{address}</p><p>idaddress : {idaddress}</p>"],
+                data: {
+                    address: f.attributes.addr3,
+                    idaddress: f.attributes.idaddress
                 },
-                scope: this
-            },
-            buttons: [{
-                text: tr("zoom"),
-                handler: function() {
-                    this.map.zoomTo(this.options.zoomLevel);
+                anchorPosition: "top-left",
+                bodyStyle: "padding: 5px;",
+                collapsible: false,
+                closable: true,
+                closeAction: "hide",
+                unpinnable: true,
+                listeners: {
+                    "hide": function() {
+                        this.layer.destroyFeatures();
+                    },
+                    scope: this
                 },
-                scope: this
-            }]
-        });
-        this.popup.show();
+                buttons: [{
+                    text: tr("zoom"),
+                    handler: function() {
+                        this.map.zoomToExtent(this.layer.getDataExtent());
+                    },
+                    scope: this
+                }]
+            });
+            this.popup.show();
+        }
+        if (this.state === "searchlane") {
+            var f = record.get('feature').clone();
+            this.layer.destroyFeatures();
+            this.popup && this.popup.destroy();
+            this.map.setCenter(f.geometry.getBounds().getCenterLonLat());
+            this.layer.addFeatures([f]);
+            this.map.zoomToExtent(this.layer.getDataExtent());
+
+        }
+
     },
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -215,7 +215,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                         }
                         grid.getStore().each(function(record) {
                             row = [];
-                            for (var c=0; c < columns.length; c++) {
+                            for (var c = 0; c < columns.length; c++) {
                                 row.push(record.get(columns[c]));
                             }
                             data.push(row);
@@ -271,8 +271,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
 
         if (storeType === "lanes") {
             proxyParams.cmd = "getlanes";
-            proxyParams.insee = "all"
-            ;
+            proxyParams.insee = "all";
             rvaFormat = OpenLayers.Format.RVALane;
             storeFields = [
                 'insee',
@@ -324,6 +323,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
 
             } else if (storeType == "addresses") {
                 proxyParams.cmd = "getaddresses";
+                proxyParams.insee = "all";
             }
         }
 
@@ -396,7 +396,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                 buttons: [{
                     text: tr("zoom"),
                     handler: function() {
-                        this.map.zoomToExtent(this.layer.getDataExtent());
+                        this.map.zoomTo(this.options.zoomLevel);
                     },
                     scope: this
                 }]

--- a/js/main.js
+++ b/js/main.js
@@ -365,10 +365,14 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
      * Callback on combo selected
      */
     _onComboSelect: function(combo, record) {
+        var f = record.get('feature').clone();
+
+        this.layer.destroyFeatures();
+        this.layerLane.destroyFeatures();
+
+        this.popup && this.popup.destroy();
+
         if (this.state === "searchaddress") {
-            var f = record.get('feature').clone();
-            this.layer.destroyFeatures();
-            this.popup && this.popup.destroy();
             this.map.setCenter(f.geometry.getBounds().getCenterLonLat());
             this.layer.addFeatures([f]);
             this.popup = new GeoExt.Popup({
@@ -402,13 +406,9 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             this.popup.show();
         }
         if (this.state === "searchlane") {
-            var f = record.get('feature').clone();
-            this.layerLane.destroyFeatures();
-            this.popup && this.popup.destroy();
             this.map.setCenter(f.geometry.getBounds().getCenterLonLat());
             this.layerLane.addFeatures([f]);
             this.map.zoomToExtent(this.layerLane.getDataExtent());
-
 
             var laneGrid = Ext.getCmp("rva-lane-grid");
             laneGrid.getStore().load({

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,7 @@
+/*global
+ Ext, GeoExt, OpenLayers, GEOR
+ */
+
 Ext.namespace("GEOR.Addons");
 
 GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
@@ -40,7 +44,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             })
         });
         clonedStyle = this.layerLane.styleMap.styles.default.clone();
-        clonedStyle.defaultStyle.label = null
+        clonedStyle.defaultStyle.label = null;
         this.layerLane.styleMap.styles.default.addRules([
             new OpenLayers.Rule({
                 minScaleDenominator: 0,
@@ -160,7 +164,7 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
                 "beforequery": {
                     fn: function(query) {
                         if (query.query === "") {
-                            return;
+
                         } else if (/^\d+/.test(query.query)) {
                             this.events.fireEvent("searchaddress", query);
                         } else {
@@ -191,7 +195,6 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
         this.target.layout.setActiveItem(this.components);
         this.target.doLayout();
 
-        me = this;
         this.laneWindow = new Ext.Window({
             //TODO tr
             title: "Adresses sur la voie",
@@ -294,8 +297,8 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
             key: this.options.key,
             version: '1.0',
             format: 'json',
-            epsg: api_srs,
-        }
+            epsg: api_srs
+        };
 
         if (storeType === "lanes") {
             storeLayer = this.layerLane;

--- a/js/main.js
+++ b/js/main.js
@@ -162,8 +162,11 @@ GEOR.Addons.RVA = Ext.extend(GEOR.Addons.Base, {
         this.popup = new GeoExt.Popup({
             location: f,
             width: 300,
-            tpl: ["<p>{addr3}</p><p>idaddress : {idaddress}</p>"],
-            data: f.attributes,
+            tpl: ["<p>{address}</p><p>idaddress : {idaddress}</p>"],
+            data: {
+                address: f.attributes.addr3,
+                idaddress: f.attributes.idaddress
+            },
             anchorPosition: "top-left",
             bodyStyle: "padding: 5px;",
             collapsible: false,

--- a/manifest.json
+++ b/manifest.json
@@ -10,12 +10,34 @@
         "zoomLevel": 18,
         "service": "http://rva.data.rennes-metropole.fr/",
         "minChars": 7,
-        "graphicStyle": {
+        "laneLabelMaxScaleDenominator": 300000,
+        "addressLabelMaxScaleDenominator": 5000,
+        "laneStyle": {
+            "strokeColor": "blue",
+            "strokeWidth": 2,
+            "fillOpacity": 0,
+            "label": "${name}, ${insee}",
+            "fontColor": "blue",
+            "fontSize": 12,
+            "fontFamily": "serif",
+            "labelYOffset": "15",
+            "labelOutlineColor": "white",
+            "labelOutlineWidth": 3
+        },
+        "addressStyle": {
             "graphicName": "star",
             "pointRadius": 4,
             "strokeColor": "fuchsia",
             "strokeWidth": 2,
-            "fillOpacity": 0
+            "fillOpacity": 0,
+            "label": "${addr2}",
+            "fontColor": "fuchsia",
+            "fontSize": 10,
+            "fontFamily": "serif",
+            "labelAlign": "cc",
+            "labelYOffset": "15",
+            "labelOutlineColor": "white",
+            "labelOutlineWidth": 3
         },
         "supported_srs": [3948, 2154, 4326]
     },

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
         "js/main.js"
     ],
     "default_options": {
+        "zoomLevel": 18,
         "target": "tabs_3",
         "zoomLevel": 18,
         "service": "http://rva.data.rennes-metropole.fr/",


### PR DESCRIPTION
With this PR, we add the ability to search lanes or address using the same combo box.

If the query typed in the combo box start with number, we search address.  If it's not the case, we search for a lane.

Lane is represented on the map by its bounding box.

A window containing every addresses is available when a lane is selected. There is an export button to obtain a CSV file of existing addresses in this window.

The PR new features make new config options available. See the README for an example.
